### PR TITLE
feat: support configure MASt3R subsample_or_initxy1 in yaml for adjus…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 This is a user-friendly implementation of **Area to Point Matching** (A2PM) framework, powered by [hydra](hydra.cc).
 
-It contains the implementation of [SGAM](https://arxiv.org/abs/2305.00194) (arXiv'23, [early-version-code](https://github.com/Easonyesheng/SGAM)), a training-free version of [MESA](https://openaccess.thecvf.com/content/CVPR2024/html/Zhang_MESA_Matching_Everything_by_Segmenting_Anything_CVPR_2024_paper.html) (CVPR'24, [project page](https://cvl.sjtu.edu.cn/getpaper/1103)) and [DMESA](https://doi.org/10.1109/TPAMI.2025.3644296) (TPAMI'26).
+It contains the implementation of [SGAM](https://arxiv.org/abs/2305.00194) (arXiv'23, [early-version-code](https://github.com/Easonyesheng/SGAM)), a training-free version of [MESA](https://openaccess.thecvf.com/content/CVPR2024/html/Zhang_MESA_Matching_Everything_by_Segmenting_Anything_CVPR_2024_paper.html) (CVPR'24, [project page](https://cvl.sjtu.edu.cn/getpaper/1103)) and [DMESA](https://doi.org/10.1109/TPAMI.2025.3644296) (TPAMI'26, [project page](https://cvl.sjtu.edu.cn/getpaper/1107)).
 
 *Due to the power of hydra, the implementation is highly configurable and easy to **extend**.*
 

--- a/conf/experiment/demo_dmesa_mast3r.yaml
+++ b/conf/experiment/demo_dmesa_mast3r.yaml
@@ -40,6 +40,10 @@ evaler:
   out_path: ${out_path}
   draw_verbose: ${verbose}
 
+# update point_matcher
+point_matcher:
+  subsample_or_initxy1: 6  # set the subsample factor for mast3r, 1 means no subsample, if you want more matches, set smaller factor
+
 
 ## update the size info for gam
 geo_area_matcher:

--- a/conf/experiment/demo_mesaf_mast3r.yaml
+++ b/conf/experiment/demo_mesaf_mast3r.yaml
@@ -40,6 +40,9 @@ evaler:
   out_path: ${out_path}
   draw_verbose: ${verbose}
 
+# update point_matcher
+point_matcher:
+  subsample_or_initxy1: 6  # set the subsample factor for mast3r, 1 means no subsample, if you want more matches, set smaller factor
 
 ## update the size info for gam
 geo_area_matcher:

--- a/point_matchers/mast3r.py
+++ b/point_matchers/mast3r.py
@@ -72,6 +72,7 @@ class Mast3rMatcher(AbstractPointMatcher):
         weight_path: str,
         device: str = 'cuda',
         fixed_shape=512, # we fix the input shape to 512x512 for mast3r #FIXME: should be configurable
+        subsample_or_initxy1: int = 8, # subsample factor for NN search
         ) -> None: 
         """
         """
@@ -81,6 +82,7 @@ class Mast3rMatcher(AbstractPointMatcher):
         self.fixed_shape = fixed_shape
         self.device = device
         self._name = "Mast3rMatcher"
+        self.subsample_or_initxy1 = subsample_or_initxy1
 
     def match(self, img0, img1, mask0: Optional[Any]=None, mask1: Optional[Any]=None) -> List[List[float]]:
         """
@@ -134,7 +136,7 @@ class Mast3rMatcher(AbstractPointMatcher):
         desc1, desc2 = pred1['desc'].squeeze(0).detach(), pred2['desc'].squeeze(0).detach()
 
         # find 2D-2D matches between the two images
-        matches_im0, matches_im1 = fast_reciprocal_NNs(desc1, desc2, subsample_or_initxy1=8,
+        matches_im0, matches_im1 = fast_reciprocal_NNs(desc1, desc2, subsample_or_initxy1=self.subsample_or_initxy1,
                                                     device=self.device, dist='dot', block_size=2**13)
         
 
@@ -219,7 +221,7 @@ class Mast3rMatcher(AbstractPointMatcher):
         desc1, desc2 = pred1['desc'].squeeze(0).detach(), pred2['desc'].squeeze(0).detach()
 
         # find 2D-2D matches between the two images
-        matches_im0, matches_im1 = fast_reciprocal_NNs(desc1, desc2, subsample_or_initxy1=8,
+        matches_im0, matches_im1 = fast_reciprocal_NNs(desc1, desc2, subsample_or_initxy1=self.subsample_or_initxy1,
                                                     device=self.device, dist='dot', block_size=2**13)
         # matches_im0, matches_im1: np.ndarray, Nx2-w,h
         match_conf_im0 = pred1['desc_conf'].squeeze(0)[matches_im0[:, 1], matches_im0[:, 0]]  # N,


### PR DESCRIPTION
### Description
Add yaml config support for MASt3R point matcher's `subsample_or_initxy1` parameter.
Users can modify this parameter in yaml file to adjust the number of match points: reduce the value to get more dense match points.

### Changes
1. Add `subsample_or_initxy1` as configurable parameter in MASt3R's __init__
2. Support modify the parameter value in main yaml config file
3. No other code changes, no breaking changes

### Type of change
- New feature (non-breaking change which adds functionality)